### PR TITLE
Add option to specify test duration

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -28,6 +28,10 @@ pub struct UserArgs {
     /// the amount of bytes to upload in a single request (default 50MB)
     #[argh(option, default = "50 * 1024 * 1024")]
     pub bytes_to_upload: usize,
+
+    /// how many seconds to run each upload/download test for (default 12)
+    #[argh(option, default = "12")]
+    pub test_duration_seconds: u64,
 }
 
 impl UserArgs {


### PR DESCRIPTION
Hi @12932,

Thank you very much for this utility, it has been helpful!

I often need to saturate a link (down and up) for up to 30 minutes for testing, so I added an option `--test-duration-seconds` to specify for how long an upload or download test should run.
It defaults to 12 and still accounts for the number of threads.

Please let me know if this is something you would accept as a PR, or if you have any suggestions or feedback.